### PR TITLE
ci(4-test-runner-script): event change from manual to pull_request

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -1,7 +1,7 @@
 name: Test Runner
 
 on:
-  workflow_dispatch
+  pull_request
 
 jobs:
   test-runner:


### PR DESCRIPTION
This PR bears the change in the test-runner script. This change is about changing the event trigger cause from `workflow_dispatch` to `pull_request` so that tests could be run for each PR.

closes #4