### PR TITLE
build(upgrade-setup-tool): addresses the REDOS vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ python-dateutil~=2.8.1
 enum34~=1.1, >=1.1.10
 apimatic-core-interfaces~=0.1.0
 requests~=2.28.1
-setuptools~=58.1.0
+setuptools~=65.5.1
 jsonpointer~=2.3

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'python-dateutil~=2.8.1',
         'requests~=2.28.1',
         'enum34~=1.1, >=1.1.10',
-        'setuptools~=58.1.0',
+        'setuptools~=65.5.1',
         'jsonpointer~=2.3'
     ],
     tests_require=[


### PR DESCRIPTION
This commit bears the fix for a vulnerability found against setup tool version 58.1.0. It is now gets upgraded to 65.5.1 which addresses the vulnerability against regular expression denial of service attacks.

closes #26