### PR TITLE
build(setuptools): bump version to 68.0.0 for setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ python-dateutil~=2.8.1
 enum34~=1.1, >=1.1.10
 apimatic-core-interfaces~=0.1.0
 requests~=2.31
-setuptools>=67.6.0
+setuptools>=68.0.0
 jsonpointer~=2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ python-dateutil~=2.8.1
 enum34~=1.1, >=1.1.10
 apimatic-core-interfaces~=0.1.0
 requests~=2.31
-setuptools~=67.6.0
+setuptools>=67.6.0
 jsonpointer~=2.3

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'python-dateutil~=2.8.1',
         'requests~=2.31',
         'enum34~=1.1, >=1.1.10',
-        'setuptools==66.0.0',
+        'setuptools>=68.0.0',
         'jsonpointer~=2.3'
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'python-dateutil~=2.8.1',
         'requests~=2.31',
         'enum34~=1.1, >=1.1.10',
-        'setuptools>=66.0.0',
+        'setuptools==66.0.0',
         'jsonpointer~=2.3'
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'python-dateutil~=2.8.1',
         'requests~=2.31',
         'enum34~=1.1, >=1.1.10',
-        'setuptools~=66.0.0',
+        'setuptools>=66.0.0',
         'jsonpointer~=2.3'
     ],
     tests_require=[


### PR DESCRIPTION
## What
This PR bumps the version of the `setuptools` dependency to the 68.0.0.

closes #49 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [x] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
