### PR TITLE
docs: compatibility with python 3.12 and 3.13

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.12", "3.13"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,6 @@
 name: Pylint Runner
 
-on: 
+on:
   workflow_dispatch
 
 jobs:
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -33,5 +33,5 @@ jobs:
         run: |
               for file in $(find -name '*.py')
               do
-               pylint --disable=R,C,W "$file" --fail-under=10;    
+               pylint --disable=R,C,W "$file" --fail-under=10;
               done

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -33,7 +33,7 @@ jobs:
       - name: Generate coverage report
         run: coverage xml
       - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.11' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.12' && github.actor != 'dependabot[bot]' }}
         uses: paambaati/codeclimate-action@v3.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Generate coverage report
         run: coverage xml
       - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.12' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.13' && github.actor != 'dependabot[bot]' }}
         uses: paambaati/codeclimate-action@v3.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -33,7 +33,7 @@ jobs:
       - name: Generate coverage report
         run: coverage xml
       - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.11' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]' }}
         uses: paambaati/codeclimate-action@v3.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.12", "3.13"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -33,7 +33,7 @@ jobs:
       - name: Generate coverage report
         run: coverage xml
       - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.11' && github.actor != 'dependabot[bot]' }}
         uses: paambaati/codeclimate-action@v3.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The APIMatic Core libraries provide a stable runtime that powers all the functio
 
 
 ## Installation
-You will need Python 3.7-3.11 to support this package.
+You will need Python 3.7+ to support this package.
 
 Simply run the command below to install the core library in your SDK. The core library will be added as a dependency your SDK.
 


### PR DESCRIPTION
## What
- Add 3.12 and 3.13 to Test Runner and Pylint Runner
- Update docs to reflect that 3.7+ is supported

## Why
Test Actions are passing for both 3.12 and 3.13

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [x] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
- Test Runner passed for 3.12 and 3.13 in core library
- Test Actions passed for 3.12 and 3.13 in SDKs & Code Samples

## Checklist
- [ ] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
